### PR TITLE
Edit requirements.txt to change how rfutils is fetched

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 nose
 networkx
--e git://github.com/Futrell/rfutils.git#egg=rfutils
+-e git+https://github.com/Futrell/rfutils.git#egg=rfutils
 conllu


### PR DESCRIPTION
Git protocol has been [turned off](https://github.blog/2021-09-01-improving-git-protocol-security-github/) due to security reasons. Hence `pip install -r requirements.txt` throws `fatal: unable to connect to github.com:
github.com[0: 140.82.121.3]: errno=Operation timed out` in the current state. More on the issue [here](https://stackoverflow.com/questions/72915782/fatal-unable-to-connect-to-github-com-github-com0-140-82-121-3-errno-opera)